### PR TITLE
 PR: T10.4.1 - 주행 알림 수신 반응 API → US10.4 머지

### DIFF
--- a/src/apis/alertsApi.ts.ts
+++ b/src/apis/alertsApi.ts.ts
@@ -1,0 +1,17 @@
+import api from '@/apis';
+
+export type AlertRenderedRequest = {
+  type: 'accident-nearby' | 'obstacle';
+  renderedAtMs: number;
+};
+
+export type AlertRenderedResponse = {
+  success: boolean;
+};
+
+export const postAlertRendered = async (
+  alertId: string,
+  data: AlertRenderedRequest,
+): Promise<AlertRenderedResponse> => {
+  return await api.post(`/api/alerts/${alertId}/rendered`, data);
+};

--- a/src/pages/driveOverlay/DriveOverlayPage.tsx
+++ b/src/pages/driveOverlay/DriveOverlayPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import styled from '@emotion/styled';
 import { selectAlerts } from '@/store/slices/alertSlice';
+import { postAlertRendered } from '@/apis/alertsApi.ts';
 import AlertToast from '@/components/common/AlertToast/AlertToast';
 import { useEmergencyHandler } from '@/hooks/useEmergencyHandler';
 import EmergencyCallAlert from '@/components/emergency/EmergencyCallAlert';
@@ -59,7 +60,7 @@ export default function DriveOverlayPage() {
   useEffect(() => {
     if (!alert || alert.id === lastAlertIdRef.current) return;
     lastAlertIdRef.current = alert.id;
-    
+
     const { type, title, content } = alert;
 
     console.warn('🚨 DriveOverlayPage alert received:', { type, title, content });
@@ -73,6 +74,14 @@ export default function DriveOverlayPage() {
     const alertItem: ActiveItem = { alertId, type, title, content, createdAt: Date.now() };
 
     setActive((prev) => [alertItem, ...prev]);
+
+    // == 유저 알림 수신 반응 시각 POST (주변사고, 장애물) ==
+    if (type === 'accident-nearby' || type === 'obstacle') {
+      postAlertRendered(alertId, {
+        type,
+        renderedAtMs: Date.now(),
+      });
+    }
 
     // 'accident' 타입이고 내 사고일 때 119 신고 모달 표시
     if (type === 'accident') {
@@ -102,7 +111,6 @@ export default function DriveOverlayPage() {
     };
   }, []);
 
-
   return (
     <OverlayContainer>
       {active.map((item, idx) => (
@@ -124,7 +132,7 @@ export default function DriveOverlayPage() {
           />
         </div>
       ))}
-  
+
       <EmergencyCallAlert
         isOpen={isEmergencyModalOpen}
         onClose={handleEmergencyModalClose}
@@ -132,7 +140,7 @@ export default function DriveOverlayPage() {
         onManualEmergencyCall={handleManualEmergencyCall}
         countdownSeconds={30}
       />
-      
+
       <EmergencyReportedAlert
         isOpen={isReportedModalOpen}
         onClose={handleReportedModalClose}


### PR DESCRIPTION
# PR: T10.4.1 - 주행 알림 수신 반응 API → US10.4 머지

## 목적

- 주행 리포트에 들어가는 사용자 알림 반응 을위해 주행중 반응한 알림의 시각에 대해서 API 연결설정이 필요. 
- 해당 기능을 US10.4 브랜치로 병합합니다.

---

## 구현/변경 사항

-  주변사고 : "accident-nearby" , 장애물 : 'obstacle' 에서 반응한 시각 요청
-  [T10.4.3] 주행 알림 반응 API #98
