### PR TITLE
PR: refactor-US10.16 - 웹소켓 로직 리팩토링 → US10.16 머지

### DIFF
--- a/src/store/websocket/websocketMiddleware.ts
+++ b/src/store/websocket/websocketMiddleware.ts
@@ -126,7 +126,7 @@ export const websocketMiddleware: Middleware =
         },
         heartbeatIncoming: 30000,
         heartbeatOutgoing: 30000,
-        reconnectDelay: 3000,
+        reconnectDelay: 0, 
         debug: (str) => console.warn('🔍 STOMP Debug:', str),
       };
       rxStomp.configure(config);

--- a/src/store/websocket/websocketMiddleware.ts
+++ b/src/store/websocket/websocketMiddleware.ts
@@ -110,8 +110,8 @@ export const websocketMiddleware: Middleware =
         connectHeaders: {
           Authorization: `Bearer ${token}`,
         },
-        heartbeatIncoming: 10000,
-        heartbeatOutgoing: 10000,
+        heartbeatIncoming: 30000,
+        heartbeatOutgoing: 30000,
         reconnectDelay: 3000,
         debug: (str) => console.warn('🔍 STOMP Debug:', str),
       };


### PR DESCRIPTION
# PR: refactor-US10.16 - 웹소켓 로직 리팩토링 → US10.16 머지

## 목적

- US10.16 웹소켓 구현 중, 연결 로직 부분 리팩토링

---

## 구현/변경 사항

- 웹소켓 하트비트 시간을 수정했습니다.
- 웹소켓 재연결 로직을 강화하여 재구현했습니다. 
-> 재연결 시도마다 최신 토큰을 가져와서 사용
-> 3번까지는 5초 간격으로 재연결 시도
-> 연결 횟수가 3번 이상이 되면 10분 간격으로 재연결을 계속 시도하도록 구현했습니다.

---

## TEST

- 로컬 테스트 완료.

---
