### PR TITLE
refactor-US10.16 - 웹소켓 로직 리팩토링 → US10.16 머지

### DIFF
--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -7,7 +7,6 @@ import { theme } from '@/styles/theme';
 import DrivePortal from '@/components/portal/DrivePortal';
 import DriveOverlayPage from '@/pages/driveOverlay/DriveOverlayPage';
 import { selectIsAuthenticated } from '@/store/slices/authSlice';
-import { ConnectionStatus } from '@/store/websocket/types';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useGetLinkStatusQuery } from '@/store/vehicle/vehicleApi';
 import BottomNav, { NAV_HEIGHT } from './BottomNav';
@@ -25,34 +24,6 @@ const Content = styled.div<{ $hasBottomNav: boolean }>`
   box-sizing: border-box;
 `;
 
-// WebSocket 상태 표시 컴포넌트 (개발용)
-const WSStatus = styled.div`
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  padding: 4px 8px;
-  background: rgba(0, 0, 0, 0.7);
-  color: white;
-  font-size: 10px;
-  border-radius: 4px;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-`;
-
-const Dot = styled.span<{ status: ConnectionStatus }>`
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: ${({ status }) =>
-    status === ConnectionStatus.CONNECTED
-      ? '#22c55e'
-      : status === ConnectionStatus.CONNECTING || status === ConnectionStatus.RECONNECTING
-        ? '#f59e0b'
-        : '#ef4444'};
-`;
 
 type RouteHandle = { hideBottomNav?: boolean };
 type MatchUnknown = { handle?: unknown };
@@ -87,7 +58,7 @@ export default function AppLayout() {
     skip: !isAuthenticated,
   });
 
-  const { connectionStatus } = useWebSocket({
+  useWebSocket({
     autoConnect: isAuthenticated && linkStatus?.linked === true,
   });
 
@@ -104,10 +75,6 @@ export default function AppLayout() {
           <DriveOverlayPage />
         </DrivePortal>
       )}
-      <WSStatus>
-        WS: {connectionStatus}
-        <Dot status={connectionStatus} />
-      </WSStatus>
     </>
   );
 }

--- a/src/store/slices/alertSlice.ts
+++ b/src/store/slices/alertSlice.ts
@@ -13,18 +13,17 @@ export interface AlertMessage {
   timestamp: string;
   isRead: boolean;
 
-  // 원문 전체
   raw?: unknown;
 }
 
 interface AlertState {
-  alerts: AlertMessage[];
+  alerts: AlertMessage | null;
   unreadCount: number;
   connectionStatus: ConnectionStatus;
 }
 
 const initialState: AlertState = {
-  alerts: [],
+  alerts: null,
   unreadCount: 0,
   connectionStatus: ConnectionStatus.DISCONNECTED,
 };
@@ -34,27 +33,27 @@ const alertSlice = createSlice({
   initialState,
   reducers: {
     addAlert: (state, action: PayloadAction<AlertMessage>) => {
-      // 최신이 위로 오도록 앞에 추가
-      state.alerts.unshift(action.payload);
+      state.alerts = action.payload;
       if (!action.payload.isRead) {
-        state.unreadCount += 1;
+        state.unreadCount = 1;
+      } else {
+        state.unreadCount = 0;
       }
     },
     markAsRead: (state, action: PayloadAction<string>) => {
-      const alert = state.alerts.find((a) => a.id === action.payload);
-      if (alert && !alert.isRead) {
-        alert.isRead = true;
-        state.unreadCount = Math.max(0, state.unreadCount - 1);
+      if (state.alerts && state.alerts.id === action.payload && !state.alerts.isRead) {
+        state.alerts.isRead = true;
+        state.unreadCount = 0;
       }
     },
     markAllAsRead: (state) => {
-      state.alerts.forEach((a) => {
-        a.isRead = true;
-      });
+      if (state.alerts) {
+        state.alerts.isRead = true;
+      }
       state.unreadCount = 0;
     },
     clearAlerts: (state) => {
-      state.alerts = [];
+      state.alerts = null;
       state.unreadCount = 0;
     },
     setConnectionStatus: (state, action: PayloadAction<ConnectionStatus>) => {
@@ -68,7 +67,7 @@ export const { addAlert, markAsRead, markAllAsRead, clearAlerts, setConnectionSt
 
 export default alertSlice.reducer;
 
-export const selectAlerts = (state: { alert: AlertState }) => state.alert.alerts[0] ?? null;
+export const selectAlerts = (state: { alert: AlertState }) => state.alert.alerts;
 export const selectUnreadCount = (state: { alert: AlertState }) => state.alert.unreadCount;
 export const selectAlertConnectionStatus = (state: { alert: AlertState }) =>
   state.alert.connectionStatus;

--- a/src/store/slices/drivingSlice.ts
+++ b/src/store/slices/drivingSlice.ts
@@ -3,11 +3,8 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import type { DrivingTendencyData } from '../websocket/types';
 
 interface DrivingState {
-  // 현재 주행 상황 전체 데이터
   currentDrivingData: DrivingTendencyData | null;
-  // 주행 세션 활성화 여부
   isActive: boolean;
-  // 마지막 업데이트 시간
   lastUpdated: string | null;
 }
 
@@ -21,25 +18,21 @@ const drivingSlice = createSlice({
   name: 'driving',
   initialState,
   reducers: {
-    // 주행 성향 데이터 업데이트 (전체 상황 덮어쓰기)
     updateDrivingTendency: (state, action: PayloadAction<DrivingTendencyData>) => {
       state.currentDrivingData = action.payload;
       state.lastUpdated = action.payload.payload.timestamp;
     },
 
-    // 주행 세션 시작
     startDrivingSession: (state) => {
       state.isActive = true;
-      state.currentDrivingData = null; // 기존 데이터 초기화
+      state.currentDrivingData = null; 
     },
 
-    // 주행 세션 종료
     endDrivingSession: (state) => {
       state.isActive = false;
-      state.currentDrivingData = null; // 데이터 초기화
+      state.currentDrivingData = null; 
     },
 
-    // 모든 주행 데이터 초기화
     clearAllDrivingData: (state) => {
       state.currentDrivingData = null;
       state.lastUpdated = null;

--- a/src/store/websocket/websocketMiddleware.ts
+++ b/src/store/websocket/websocketMiddleware.ts
@@ -356,9 +356,6 @@ export const websocketMiddleware: Middleware =
             console.warn('🚨 추출된 ID:', id);
             console.warn('🚨 서버에서 온 ID:', idFromServer);
 
-            if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
-              new Notification(title || '🚨 사고 알림', { body: display, icon: '/favicon.ico' });
-            }
           } catch (error) {
             console.error('❌ 사고 알림 처리 오류:', error);
             dispatch(setError((error as Error)?.message ?? 'incident handling error'));


### PR DESCRIPTION
# PR: refactor-US10.16 - 웹소켓 로직 리팩토링 → US10.16 머지

## 목적

- 웹소켓 로직을 리팩토링 했습니다.

---

## 구현/변경 사항

- 웹소켓 사고 알림 수신 부분을 배열 -> 객체 (주행 성향과 같은 방식) 으로 리팩토링 했습니다.
- 웹소켓 연결 확인용(개발용) 상태바를 제거했습니다.
- 그 외, 불필요한 주석과 코드를 제거했습니다.

---

## TEST

- 로컬 테스트 완료. (start, end, accident 타입)

---
